### PR TITLE
Fixed Magento 2.4.4: PHP Fatal error: Invoke declaration of Monolog\Processor

### DIFF
--- a/Processor/MemoryPeakUsageProcessor.php
+++ b/Processor/MemoryPeakUsageProcessor.php
@@ -8,7 +8,7 @@ class MemoryPeakUsageProcessor extends \Monolog\Processor\MemoryPeakUsageProcess
 
     const XML_PATH_ADD_MEMORY_PEAK_PROCESSOR = 'extended_exception/processors/memory_peak_processor';
 
-    public function __invoke(array $record)
+    public function __invoke(array $record): array
     {
         if(!$this->getConfig(self::XML_PATH_ADD_MEMORY_PEAK_PROCESSOR)) {
             return $record;

--- a/Processor/MemoryUsageProcessor.php
+++ b/Processor/MemoryUsageProcessor.php
@@ -8,7 +8,7 @@ class MemoryUsageProcessor extends \Monolog\Processor\MemoryUsageProcessor
 
     const XML_PATH_ADD_MEMORY_USAGE_PROCESSOR = 'extended_exception/processors/memory_usage_processor';
 
-    public function __invoke(array $record)
+    public function __invoke(array $record): array
     {
         if(!$this->getConfig(self::XML_PATH_ADD_MEMORY_USAGE_PROCESSOR)) {
             return $record;

--- a/Processor/WebProcessor.php
+++ b/Processor/WebProcessor.php
@@ -8,7 +8,7 @@ class WebProcessor extends \Monolog\Processor\WebProcessor
 
     const XML_PATH_ADD_WEB_PROCESSOR = 'extended_exception/processors/web_processor';
 
-    public function __invoke(array $record)
+    public function __invoke(array $record): array
     {
         if(!$this->getConfig(self::XML_PATH_ADD_WEB_PROCESSOR)) {
             return $record;


### PR DESCRIPTION
Fixes of PHP Fatal error after Magento 2.4.4 installation:

```
PHP Fatal error:  Declaration of MageSuite\ExtendedException\Processor\WebProcessor::__invoke(array $record) must be compatible with Monolog\Processor\WebProcessor::__invoke(array $record): array in /vendor/creativestyle/magesuite-extended-exception/Processor/WebProcessor.php on line 11


PHP Fatal error:  Declaration of MageSuite\ExtendedException\Processor\MemoryPeakUsageProcessor::__invoke(array $record) must be compatible with Monolog\Processor\MemoryPeakUsageProcessor::__invoke(array $record): array in /vendor/creativestyle/magesuite-extended-exception/Processor/MemoryPeakUsageProcessor.php on line 11


PHP Fatal error:  Declaration of MageSuite\ExtendedException\Processor\MemoryUsageProcessor::__invoke(array $record) must be compatible with Monolog\Processor\MemoryUsageProcessor::__invoke(array $record): array in /vendor/creativestyle/magesuite-extended-exception/Processor/MemoryUsageProcessor.php on line 11
```